### PR TITLE
Allow `onError` function to throw errors directly to lambda

### DIFF
--- a/context.js
+++ b/context.js
@@ -38,14 +38,6 @@ module.exports = {
 		return Promise.resolve()
 			.then(() => app.errorCb(err))
 			.then(() => context.fail(msg))
-			.catch(error => {
-				if (error) {
-					context.fail(error);
-
-					return;
-				}
-
-				context.fail(msg);
-			});
+			.catch(error => context.fail(error || msg));
 	}
 };

--- a/context.js
+++ b/context.js
@@ -37,6 +37,15 @@ module.exports = {
 		// Call the error callback and fail
 		return Promise.resolve()
 			.then(() => app.errorCb(err))
-			.then(() => context.fail(msg));
+			.then(() => context.fail(msg))
+			.catch(error => {
+				if (error) {
+					context.fail(error);
+
+					return;
+				}
+
+				context.fail(msg);
+			});
 	}
 };

--- a/test/context.js
+++ b/test/context.js
@@ -42,3 +42,37 @@ test('onerror should call correct handlers', async t => {
 
 	await context.onerror(app, ctx, 'Not Found');
 });
+
+test('should return with a message when `app.errorCb` does not throw', async t => {
+	t.plan(1);
+
+	const app = {
+		errorCb: () => {}
+	};
+
+	const ctx = {
+		fail(message) {
+			t.is(message, '500 - Internal Server Error');
+		}
+	};
+
+	await context.onerror(app, ctx, 'Not Found');
+});
+
+test('should error when `app.errorCb` does throws', async t => {
+	t.plan(1);
+
+	const app = {
+		errorCb: () => {
+			throw new Error('Error from `errorCb`');
+		}
+	};
+
+	const ctx = {
+		fail(err) {
+			t.is(err.message, 'Error from `errorCb`');
+		}
+	};
+
+	await context.onerror(app, ctx, 'Not Found');
+});


### PR DESCRIPTION
Right how it is not possible to throw an error and expose it directly to lambda. With these changes it is possible to throw in the `onError` function of the app. If an error is thrown inside the `onError` callback it will be used to hard throw the lambda function. If the `onError` does not throw, it returns the message like it would have before.